### PR TITLE
keep seminars from disappearing before they start.

### DIFF
--- a/lco_global/lcogt/views.py
+++ b/lco_global/lcogt/views.py
@@ -57,7 +57,7 @@ def user_profile(request,username):
     return render(request, 'pages/userprofile.html', {'profile': profile,'papers':papers})
 
 def seminar_home(request):
-    starttime = datetime.utcnow() - timedelta(minutes=360)
+    starttime = datetime.utcnow() - timedelta(hours=9)
     seminars = Seminar.objects.filter(seminardate__gt=starttime).order_by('seminardate')
     if seminars:
         nearest_seminar = seminars.order_by('seminardate')[0]


### PR DESCRIPTION
This will adequately address issue #10. 

All I really want is for the seminar to stay on the main page until after it's over. 
Considering that `PST = UTC - 8` and `PDT = UTC - 7`, Changing this delay from 6 to 9 hours should always accomplish that goal.

I think the "correct" method would be to ingest `Seminar.seminardate` with the correct time zone information then convert for the comparison, but time zones are stupid and this is sufficient. 