### PR TITLE
Make built in mezzanine urls take more precedence

### DIFF
--- a/lco_global/lcogt_mezzanine/urls.py
+++ b/lco_global/lcogt_mezzanine/urls.py
@@ -48,12 +48,12 @@ urlpatterns = [
 
     # Announcement URL structure in News
     # ----------------
+    url(r"^", include("mezzanine.urls")),
     url("^news/category/(?P<category>.*)/$", blogv.blog_post_list, name="blog_post_list_category"),
     url("^news/(?P<slug>.*)/$", blogv.blog_post_detail, name="blog_post_detail"),
     url("^news/$", lco_blog_post_list, name="blog_post_list"),
 
     url(r'^admin/', include(admin.site.urls)),
-    url(r"^", include("mezzanine.urls")),
     url(r'^accounts/', include('django.contrib.auth.urls'))
     ]
 


### PR DESCRIPTION
The custom news url was taking precedence over the built in mezzanine
urls which caused the RSS feeds to break. This PR shuffles the url
patterns around a bit to make the feeds work. Fixes #14 